### PR TITLE
Add Flask backend and front-end for cluster results

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ Este repositorio incluye un script de ejemplo para realizar agrupamiento (cluste
 - pandas
 - scikit-learn
 - matplotlib
+- flask
 
 Puedes instalar las dependencias con:
 
 ```bash
-pip install pandas scikit-learn matplotlib
+pip install pandas scikit-learn matplotlib flask
 ```
 
 ## Uso
@@ -24,3 +25,13 @@ python kmeans_analysis.py
 ```
 
 Se imprimirán los centroides, la inercia del modelo y se mostrará una gráfica con los clusters obtenidos.
+
+## Servidor web
+
+También puedes iniciar un pequeño servidor Flask que expone los resultados en formato JSON y una página web para visualizarlos:
+
+```bash
+python app.py
+```
+
+Abre tu navegador en `http://localhost:5000` para ver la página `index.html` que consume los datos del endpoint `/clusters`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,18 @@
+from flask import Flask, jsonify
+from kmeans_analysis import perform_kmeans
+
+app = Flask(__name__)
+
+@app.route('/clusters')
+def clusters():
+    centroids, inertia, df, feature_names = perform_kmeans()
+    result = {
+        'centroids': centroids.to_dict(orient='records'),
+        'inertia': inertia,
+        'data': df.to_dict(orient='records'),
+        'features': feature_names
+    }
+    return jsonify(result)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/index.html
+++ b/index.html
@@ -1,9 +1,40 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>Home</title>
+    <meta charset="utf-8">
+    <title>Clusters</title>
 </head>
 <body>
- <video src="https://www.youtube.com/watch?v=kN1XP-Bef7w" controls > </video>
+    <h1>Resultado de KMeans</h1>
+    <div id="inertia"></div>
+    <h2>Centroides</h2>
+    <table id="centroids" border="1"></table>
+
+    <script>
+        fetch('/clusters')
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('inertia').textContent = 'Inercia: ' + data.inertia;
+
+                const table = document.getElementById('centroids');
+                const headerRow = document.createElement('tr');
+                data.features.forEach(f => {
+                    const th = document.createElement('th');
+                    th.textContent = f;
+                    headerRow.appendChild(th);
+                });
+                table.appendChild(headerRow);
+
+                data.centroids.forEach(row => {
+                    const tr = document.createElement('tr');
+                    data.features.forEach(f => {
+                        const td = document.createElement('td');
+                        td.textContent = row[f].toFixed(2);
+                        tr.appendChild(td);
+                    });
+                    table.appendChild(tr);
+                });
+            });
+    </script>
 </body>
 </html>

--- a/kmeans_analysis.py
+++ b/kmeans_analysis.py
@@ -4,29 +4,34 @@ from sklearn.cluster import KMeans
 import matplotlib.pyplot as plt
 
 
-def main():
-    # Cargar datos de ejemplo
+def perform_kmeans():
+    """Run KMeans on the iris dataset and return results."""
     iris = load_iris()
-    X = pd.DataFrame(iris.data, columns=iris.feature_names)
+    df = pd.DataFrame(iris.data, columns=iris.feature_names)
 
-    # Crear modelo KMeans con 3 clusters
     model = KMeans(n_clusters=3, random_state=42)
-    model.fit(X)
+    model.fit(df)
 
-    # Añadir las etiquetas de cluster a los datos
-    X['cluster'] = model.labels_
+    df["cluster"] = model.labels_
 
-    # Mostrar centroides e inercia
-    print('Centroides:')
-    print(pd.DataFrame(model.cluster_centers_, columns=iris.feature_names))
-    print('\nInercia:', model.inertia_)
+    centroids = pd.DataFrame(model.cluster_centers_, columns=iris.feature_names)
+    inertia = model.inertia_
 
-    # Graficar dos de las variables para ver los clusters
+    return centroids, inertia, df, iris.feature_names
+
+
+def main():
+    centroids, inertia, df, feature_names = perform_kmeans()
+
+    print("Centroides:")
+    print(centroids)
+    print("\nInercia:", inertia)
+
     plt.figure(figsize=(8, 6))
-    scatter = plt.scatter(X[iris.feature_names[0]], X[iris.feature_names[1]], c=X['cluster'])
-    plt.xlabel(iris.feature_names[0])
-    plt.ylabel(iris.feature_names[1])
-    plt.title('Clusters con KMeans')
+    plt.scatter(df[feature_names[0]], df[feature_names[1]], c=df["cluster"])
+    plt.xlabel(feature_names[0])
+    plt.ylabel(feature_names[1])
+    plt.title("Clusters con KMeans")
     plt.show()
 
 


### PR DESCRIPTION
## Summary
- expose clustering results through a Flask app
- display cluster centroids in the web UI
- refactor `kmeans_analysis.py` into reusable function
- update README with new instructions

## Testing
- `python -m py_compile kmeans_analysis.py app.py`
- `python kmeans_analysis.py`
- `python app.py` *(hit `/clusters` once with curl)*

------
https://chatgpt.com/codex/tasks/task_e_68492127a67c832e9aad78c05ffc0676